### PR TITLE
add OCaml implementation

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -412,6 +412,10 @@ A Monkey implementation written in Typescript by <a href="https://xavd.id">David
 A complete Monkey implementation, including macros, written in Kotlin
 {{< /monkey-implementation >}}
 
+{{< monkey-implementation "ryo-imai-bit" "Writing-An-Interpreter-In-Go-In-OCaml" "OCaml">}}
+An implementation of Monkey interpreter in OCaml, including macros.
+{{< /monkey-implementation >}}
+
 <li class="mb-4 p-3 border border-light-grey rounded monkey-implementation">
   <div class="d-flex">
     <div>


### PR DESCRIPTION
add [OCaml implementation](https://github.com/ryo-imai-bit/Writing-An-Interpreter-In-Go-In-OCaml).