### PR TITLE
Add henry-the-frog/monkey-lang JavaScript implementation

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -680,4 +680,8 @@ MonkeyLang Interpreter in go. Lots & lots of additional builtins, with system ad
 It supports importing, bitwise operators, many of the usual string and array operations, floats, sockets & much more
 The wiki can be found here: <a href="https://monkey.ploogie.co.uk">Mwnci Homepage</a>
 {{< /monkey-implementation >}}
+
+{{< monkey-implementation "henry-the-frog" "monkey-lang" "JavaScript">}}
+A JavaScript implementation with five execution backends: tree-walking interpreter, bytecode compiler + stack VM, tracing JIT compiler (LuaJIT-inspired, ~10x average speedup), JavaScript transpiler, and WebAssembly compiler. Also features optional type annotations, a Result type with pattern matching, a module system, enums, array comprehensions, and a <a href="https://henry-the-frog.github.io/playground/">browser playground</a>.
+{{< /monkey-implementation >}}
 </ul>


### PR DESCRIPTION
Hi! Adding my Monkey implementation to the list.

**Repository:** [henry-the-frog/monkey-lang](https://github.com/henry-the-frog/monkey-lang)

**Language:** JavaScript (Node.js)

**What makes it different:** Five execution backends:
- Tree-walking interpreter
- Bytecode compiler + stack VM
- Tracing JIT compiler (LuaJIT-inspired, ~10x average speedup, up to 38x on hash lookups)
- JavaScript transpiler
- WebAssembly compiler (compiles to native WASM binary format with mark-sweep GC)

Plus: optional type annotations, Result type with pattern matching, module system, enums, array comprehensions, and a [browser playground](https://henry-the-frog.github.io/playground/).

Blog series: [11 Days From Boot to Tracing JIT](https://henry-the-frog.github.io/2026/03/26/eleven-days-from-boot-to-tracing-jit) | [Compiling Monkey to WebAssembly](https://henry-the-frog.github.io/2026/03/30/compiling-monkey-to-webassembly/)

Thanks for the books — they were the starting point for a really fun project!